### PR TITLE
Enhance admin privilege request flow and feedback for register and uninstall script

### DIFF
--- a/build/x64/Release/register.cmd
+++ b/build/x64/Release/register.cmd
@@ -1,16 +1,36 @@
 @echo off
 
+title Asking for administrator access
+mode CON COLS=37 LINES=3
+color F0
+echo :::::::::::::::::::::::::::::::::::::
+echo :: Requesting administrator access ::
+echo :::::::::::::::::::::::::::::::::::::
+cd /d "%~dp0" && ( if exist "%temp%\getadmin.vbs" del "%temp%\getadmin.vbs" ) && fsutil dirty query %systemdrive% 1>nul 2>nul || (  cmd /u /c echo Set UAC = CreateObject^("Shell.Application"^) : UAC.ShellExecute "cmd.exe", "/k cd ""%~sdp0"" && ""%~s0"" %Apply%", "", "runas", 1 >> "%temp%\getadmin.vbs" && "%temp%\getadmin.vbs" && exit /B )
+color
+cls
+
+title Applying
 call :isAdmin
 if %errorlevel% == 0 (
+    echo Applying effects
 	regsvr32 "%~dp0ExplorerBlurMica.dll"
+    echo.
 ) else (
-	echo ÇëÒÔ¹ÜÀíÔ±Éí·ÝÔËÐÐ!
+	echo ï¿½ï¿½ï¿½Ô¹ï¿½ï¿½ï¿½Ô±ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½!
 	echo Please run as Administrator
 )
 
-pause >nul
-exit /b
+echo Restarting explorer
+taskkill /F /IM explorer.exe >nul
+start explorer.exe
+echo .
+echo title Success
+echo Changes applied successfully
+echo You can now close this window, it will close automatically in 5 seconds
+timeout /t 5 >nul
+exit /b 0
 
 :isAdmin
 fsutil dirty query %systemdrive% >nul
-exit /b
+exit /b %errorlevel%

--- a/build/x64/Release/uninstall.cmd
+++ b/build/x64/Release/uninstall.cmd
@@ -1,17 +1,35 @@
 @echo off
 
+title Asking for administrator access
+mode CON COLS=37 LINES=3
+color F0
+echo :::::::::::::::::::::::::::::::::::::
+echo :: Requesting administrator access ::
+echo :::::::::::::::::::::::::::::::::::::
+cd /d "%~dp0" && ( if exist "%temp%\getadmin.vbs" del "%temp%\getadmin.vbs" ) && fsutil dirty query %systemdrive% 1>nul 2>nul || (  cmd /u /c echo Set UAC = CreateObject^("Shell.Application"^) : UAC.ShellExecute "cmd.exe", "/k cd ""%~sdp0"" && ""%~s0"" %Apply%", "", "runas", 1 >> "%temp%\getadmin.vbs" && "%temp%\getadmin.vbs" && exit /B )
+color
+cls
+
+title Uninstalling
 call :isAdmin
 if %errorlevel% == 0 (
 	regsvr32 /u "%~dp0ExplorerBlurMica.dll"
-	taskkill /f /im explorer.exe & explorer.exe
+    echo.
 ) else (
-	echo ÇëÒÔ¹ÜÀíÔ±Éí·ÝÔËÐÐ! 
+	echo ï¿½ï¿½ï¿½Ô¹ï¿½ï¿½ï¿½Ô±ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½ï¿½! 
 	echo Please run as Administrator
 )
 
-pause >nul
-exit /b
+echo Restarting explorer
+taskkill /F /IM explorer.exe >nul
+start explorer.exe
+echo .
+echo title Success
+echo Changes applied successfully
+echo You can now close this window, it will close automatically in 5 seconds
+timeout /t 5 >nul
+exit /b 0
 
 :isAdmin
 fsutil dirty query %systemdrive% >nul
-exit /b
+exit /b %errorlevel%


### PR DESCRIPTION
Expanded the register.cmd and uninstall.cmd script to provide a clear and user-friendly interface when requesting administrator access. If admin rights are not present, the script now explains the necessity of admin privileges with a styled message box. On successful execution as admin, it now also confirms the registration of the DLL, restarts the Windows Explorer, provides success feedback, and auto-closes after 5 seconds for a smoother user experience. The changes ensure that users are better informed about what the script is doing and that the effects are applied without requiring additional manual steps.